### PR TITLE
Checkin local CyberChef TF module into Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-# terraform-aws-cyberchef
-Terraform to setup CyperChef in AWS
+Terraform code for settting up AWS infrastracture, which include iam, alb, dns, ecs and various network resources, to host CyberChef applicing running in a Docker container.

--- a/alb.tf
+++ b/alb.tf
@@ -1,0 +1,40 @@
+# Creates the following resources:
+# 1. Application Load Balancer
+# 2. The Target Group for the ALB
+# 3. The listener front-end that faces the internet, with ACM TLS cert
+
+resource "aws_alb" "main" {
+  name            = "${local.name_prefix}-alb"
+  subnets         = aws_subnet.public.*.id
+  security_groups = [aws_security_group.alb.id]
+}
+
+resource "aws_alb_target_group" "cyberchef" {
+  name        = "${local.name_prefix}-tg"
+  port        = 80     # This is 80, even though it doesn't match the listener or the container port.
+  protocol    = "HTTP" # This is again HTTP and doesn't match the listener.
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    port = var.container_port
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Redirect HTTPS traffic from the ALB to the target group
+resource "aws_alb_listener" "front_end" {
+  load_balancer_arn = aws_alb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = data.aws_acm_certificate.cyberchef_issued.arn
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-2019-08"
+
+  default_action {
+    target_group_arn = aws_alb_target_group.cyberchef.arn
+    type             = "forward"
+  }
+}

--- a/auto_scaling.tf
+++ b/auto_scaling.tf
@@ -1,0 +1,91 @@
+resource "aws_appautoscaling_target" "target" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.cyberchef.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  min_capacity       = 1
+  max_capacity       = 3
+}
+
+# Automatically scale capacity up by one
+resource "aws_appautoscaling_policy" "up" {
+  count              = var.use_auto_scaling ? 1 : 0
+  name               = "cyberchef_scale_up"
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.cyberchef.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+
+  depends_on = [aws_appautoscaling_target.target]
+}
+
+# Automatically scale capacity down by one
+resource "aws_appautoscaling_policy" "down" {
+  count              = var.use_auto_scaling ? 1 : 0
+  name               = "cyberchef_scale_down"
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.cyberchef.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+
+  depends_on = [aws_appautoscaling_target.target]
+}
+
+# CloudWatch alarm that triggers the autoscaling up policy
+resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
+  count               = var.use_auto_scaling ? 1 : 0
+  alarm_name          = "cyberchef_cpu_utilization_high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "85"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.cyberchef.name
+  }
+
+  alarm_actions = [aws_appautoscaling_policy.up[count.index].arn]
+}
+
+# CloudWatch alarm that triggers the autoscaling down policy
+resource "aws_cloudwatch_metric_alarm" "service_cpu_low" {
+  count               = var.use_auto_scaling ? 1 : 0
+  alarm_name          = "cyberchef_cpu_utilization_low"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "10"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.cyberchef.name
+  }
+
+  alarm_actions = [aws_appautoscaling_policy.down[count.index].arn]
+}

--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,26 @@
+data "aws_route53_zone" "security" {
+  name         = var.hosted_zone
+  private_zone = var.hosted_zone_private
+}
+
+resource "aws_route53_record" "cyberchef_a_record" {
+  zone_id = data.aws_route53_zone.security.zone_id
+  name    = var.cyberchef_domain_name
+  type    = var.hosted_zone_private ? "CNAME" : "A"
+  records = var.hosted_zone_private ? [aws_alb.main.dns_name] : null
+  ttl     = var.hosted_zone_private ? 300 : null
+
+  dynamic "alias" {
+    for_each = var.hosted_zone_private ? [] : [1]
+    content {
+      name                   = aws_alb.main.dns_name
+      zone_id                = aws_alb.main.zone_id
+      evaluate_target_health = true
+    }
+  }
+}
+
+data "aws_acm_certificate" "cyberchef_issued" {
+  domain   = var.cyberchef_domain_cert
+  statuses = ["ISSUED"]
+}

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,0 +1,71 @@
+# Creates the following resources:
+# 1. ECS Cluster
+# 2. Template file for ECS task definition
+# 3. The actual ECS task definition using the template from 2.
+# 4. ECS service using the task definition from 3.
+resource "aws_ecs_cluster" "main" {
+  name = "cyberchef-cluster"
+}
+
+# data "template_file" "cyberchef" {
+#   template = file("${path.module}/templates/ecs/cyberchef.json.tpl")
+
+#   vars = {
+#     app_image        = var.app_image
+#     host_port        = var.host_port
+#     container_port   = var.container_port
+#     fargate_cpu      = var.fargate_cpu
+#     fargate_memory   = var.fargate_memory
+#     aws_region       = var.aws_region
+#     cloudwatch_group = local.name_prefix
+#     env              = var.env
+#   }
+# }
+
+
+# Cyberchef Service
+resource "aws_ecs_task_definition" "cyberchef" {
+  family                   = "${local.name_prefix}-task-def"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.fargate_cpu
+  memory                   = var.fargate_memory
+  container_definitions    = templatefile("${path.module}/templates/ecs/cyberchef.json.tpl",
+    {
+    app_image        = var.app_image
+    host_port        = var.host_port
+    container_port   = var.container_port
+    fargate_cpu      = var.fargate_cpu
+    fargate_memory   = var.fargate_memory
+    aws_region       = var.aws_region
+    cloudwatch_group = local.name_prefix
+    env              = var.env
+    }
+  )
+  }
+
+resource "aws_ecs_service" "cyberchef" {
+  name                              = "${local.name_prefix}-service"
+  cluster                           = aws_ecs_cluster.main.id
+  task_definition                   = aws_ecs_task_definition.cyberchef.arn
+  desired_count                     = var.app_count
+  launch_type                       = "FARGATE"
+  health_check_grace_period_seconds = 60
+
+  network_configuration {
+    security_groups  = [aws_security_group.ecs.id]
+    subnets          = aws_subnet.private.*.id
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.cyberchef.arn
+    container_name   = "cyberchef"
+    container_port   = var.container_port
+  }
+
+  depends_on = [
+    aws_alb_listener.front_end,
+    aws_iam_role_policy_attachment.attach_task_execution
+  ]
+}

--- a/logs.tf
+++ b/logs.tf
@@ -1,0 +1,5 @@
+# Set up CloudWatch groups and streams for ECS Containers
+resource "aws_cloudwatch_log_group" "cyberchef_service_log_group" {
+  name              = "/aws/${local.name_prefix}"
+  retention_in_days = var.log_retention_days
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,101 @@
+# Creates the following resources:
+# 1. VPC for all cyberchef resources
+# 2. Public and Private Subnets
+# 3. Internet Gateway
+# 4. IG NAT Gateway for public subnets
+
+# Fetch AZs in the current region
+data "aws_availability_zones" "available" {
+}
+
+locals {
+  name_prefix = "${var.app_name}-${var.env}"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "CyberChef Main VPC"
+  }
+}
+
+# Create var.az_count private subnets, each in a different AZ
+resource "aws_subnet" "private" {
+  count             = var.az_count
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.main.id
+}
+
+# Create var.az_count public subnets, each in a different AZ
+resource "aws_subnet" "public" {
+  count                   = var.az_count
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, var.az_count + count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  vpc_id                  = aws_vpc.main.id
+  map_public_ip_on_launch = true
+}
+
+# Internet Gateway for the public subnet
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-gw"
+  }
+}
+
+# Route the public subnet traffic through the IGW
+resource "aws_route" "internet_access" {
+  route_table_id         = aws_vpc.main.main_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gw.id
+}
+
+# Create a NAT gateway with an Elastic IP for each private subnet to get internet connectivity
+resource "aws_eip" "gw" {
+  count      = var.az_count
+  vpc        = true
+  depends_on = [aws_internet_gateway.gw]
+
+  tags = {
+    Name = "${local.name_prefix}-gw-eip"
+  }
+}
+
+resource "aws_nat_gateway" "gw" {
+  count         = var.az_count
+  subnet_id     = element(aws_subnet.public.*.id, count.index)
+  allocation_id = element(aws_eip.gw.*.id, count.index)
+
+  tags = {
+    Name = local.name_prefix
+  }
+
+  depends_on = [aws_internet_gateway.gw]
+}
+
+# Create a new route table for the private subnets, make it route non-local traffic through the NAT gateway to the internet
+resource "aws_route_table" "private" {
+  count  = var.az_count
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = element(aws_nat_gateway.gw.*.id, count.index)
+  }
+
+  tags = {
+    Name = local.name_prefix
+  }
+}
+
+# Explicitly associate the newly created route tables to the private subnets (so they don't default to the main route table)
+resource "aws_route_table_association" "private" {
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "alb_hostname" {
+  value = aws_alb.main.dns_name
+}

--- a/roles.tf
+++ b/roles.tf
@@ -1,0 +1,29 @@
+# ECS task execution role data
+data "aws_iam_policy_document" "ecs_task_execution_role" {
+  version = "2012-10-17"
+  statement {
+    sid = ""
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy" "ecs_task_execution_role_policy" {
+  name = "AmazonECSTaskExecutionRolePolicy"
+}
+
+# ECS task execution role
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = var.ecs_task_execution_role_name
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach_task_execution" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = data.aws_iam_policy.ecs_task_execution_role_policy.arn
+}

--- a/security.tf
+++ b/security.tf
@@ -1,0 +1,46 @@
+# ALB Security Group: Will only open to VPN Dev.
+resource "aws_security_group" "alb" {
+  name        = "${local.name_prefix}-alb-sg"
+  description = "controls access to the ALB to allow HTTP traffic only from the dev vpn."
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "TCP traffic from allowed blocks."
+    protocol    = "tcp"
+    from_port   = var.host_port
+    to_port     = var.host_port
+    cidr_blocks = var.allowed_cidr_blocks
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Traffic to the ECS cluster should only come from the ALB
+resource "aws_security_group" "ecs" {
+  name        = "${local.name_prefix}-ecs-tasks-sg"
+  description = "allow inbound access from the ALB only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = var.container_port
+    to_port         = var.container_port
+    security_groups = [aws_security_group.alb.id] 
+    }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/templates/ecs/cyberchef.json.tpl
+++ b/templates/ecs/cyberchef.json.tpl
@@ -1,0 +1,24 @@
+[
+  {
+    "essential": true,
+    "name": "cyberchef",
+    "memory": ${fargate_memory},
+    "cpu": ${fargate_cpu},
+    "image": "${app_image}",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "/aws/${cloudwatch_group}",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "ecs"
+      }
+    },
+    "portMappings": [
+      {
+        "containerPort": ${container_port},
+        "hostPort": ${container_port},
+        "protocol": "tcp"
+      }
+    ]
+  }
+]

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,115 @@
+variable "aws_region" {
+  description = "The AWS region in which things are created."
+  default     = "us-east-2"
+}
+
+variable "cidr_block" {
+  type        = string
+  description = "AWS VPC cidr"
+}
+
+variable "env" {
+  type        = string
+  description = "Environment under which this is being deployed."
+  default     = "prod"
+}
+
+variable "app_name" {
+  description = "Name of the app."
+  type        = string
+  default     = "cyberchef"
+}
+
+variable "ecs_task_execution_role_name" {
+  description = "ECS task execution role name."
+  default     = "cyberchefEcsTaskExecutionRole"
+}
+
+variable "log_level" {
+  description = "Log level."
+  default     = "DEBUG"
+}
+
+variable "az_count" {
+  description = "Number of AZs to cover in a given region."
+  default     = "2"
+}
+
+variable "app_image" {
+  description = "Docker image to run in the ECS cluster."
+}
+
+variable "host_port" {
+  description = "Port exposed by the docker image to redirect traffic to."
+  default     = 443
+}
+
+variable "protocol" {
+  description = "Protocol use for cyberchef URL."
+  type        = string
+  default     = "HTTPS"
+}
+
+variable "log_retention_days" {
+  description = "Log retention period in days."
+  default     = 0
+}
+
+variable "container_port" {
+  description = "Port exposed by the cyberchef container."
+  default     = 8000
+}
+
+variable "app_count" {
+  description = "Number of docker containers to run."
+  default     = 1
+}
+
+variable "health_check_path" {
+  description = "ALB Health Check"
+  default     = "/"
+  type        = string
+}
+
+variable "fargate_cpu" {
+  description = "Fargate instance CPU units to provision (1 vCPU = 1024 CPU units)."
+  default     = 4096
+}
+
+variable "fargate_memory" {
+  description = "Fargate instance memory to provision (in MiB)"
+  default     = 8192
+}
+
+variable "cyberchef_domain_name" {
+  description = "Domain name used."
+}
+
+variable "allowed_cidr_blocks" {
+  description = "Allowed list of CIDR Blocks."
+  type        = list(string)
+  default     = ["54.213.100.75/32"]
+}
+
+variable "use_auto_scaling" {
+  description = "Set this variable to 'true' to tell autoscaling triggers"
+  type        = bool
+  default     = false
+}
+
+variable "cyberchef_domain_cert" {
+  description = "Cert used by CyberChef ALB."
+  type        = string
+}
+
+variable "hosted_zone" {
+  description = "Hosted zone used by the deployment."
+  type        = string
+}
+
+variable "hosted_zone_private" {
+  description = "Hosted zone is a private zone."
+  type        = bool
+  default     = false
+}
+


### PR DESCRIPTION
@sfc-gh-esamsunder , please review and comment.  Just a checkin of your TF CyberChef module into its own repo.  I made some minor update to support private DNS.  We should be able to use this module for both Com and FRH.  This should allow us to do versioning.  For now, I just need this to provision CyberChef in FRH but we should be able to switch the Com environment to his as this module was copied from the Com one.